### PR TITLE
Clarify fallback decoding

### DIFF
--- a/src/aggregator.py
+++ b/src/aggregator.py
@@ -7,8 +7,8 @@ def gather_documents(input_dir: Path) -> List[Tuple[str, str]]:
 
     Each file is decoded as UTF-8 first. On ``UnicodeDecodeError`` the
     function attempts ``cp1251``. If decoding still fails the file is read in
-    binary mode and decoded with ``errors='replace'`` so an exception is never
-    raised.
+    binary mode and decoded using UTF-8 with ``errors='replace'`` so an
+    exception is never raised.
     """
     groups = {}
     for path in input_dir.glob('*.txt'):


### PR DESCRIPTION
## Summary
- document that gather_documents falls back to UTF-8 with errors='replace'

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ff22cd240832b85b73e793675fe9f