### PR TITLE
Ensure stable document ordering

### DIFF
--- a/src/aggregator.py
+++ b/src/aggregator.py
@@ -11,7 +11,7 @@ def gather_documents(input_dir: Path) -> List[Tuple[str, str]]:
     raised.
     """
     groups = {}
-    for path in input_dir.glob('*.txt'):
+    for path in sorted(input_dir.glob('*.txt')):
         stem = path.stem.split('_')[0]  # assumes `act1_part1.txt` pattern
         groups.setdefault(stem, []).append(path)
 

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -13,3 +13,22 @@ def test_cp1251_file_reading():
 
         docs = gather_documents(path)
         assert docs == [('doc1', text)]
+
+
+def test_stable_document_order():
+    """Documents should be returned in alphabetical order regardless of creation order."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir)
+
+        # Create files in reverse alphabetical order to simulate unpredictable filesystem ordering
+        (path / 'doc2_part2.txt').write_text('two_part2')
+        (path / 'doc2_part1.txt').write_text('two_part1')
+        (path / 'doc1_part2.txt').write_text('one_part2')
+        (path / 'doc1_part1.txt').write_text('one_part1')
+
+        docs = gather_documents(path)
+
+        assert docs == [
+            ('doc1', 'one_part1\none_part2'),
+            ('doc2', 'two_part1\ntwo_part2'),
+        ]


### PR DESCRIPTION
## Summary
- make `gather_documents` iterate over sorted input paths
- add regression test that document order is independent of filesystem order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ff22d9600832bb1e3c4f97f924974