### PR TITLE
Add test for multi-file UTF-8 assembly

### DIFF
--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -13,3 +13,15 @@ def test_cp1251_file_reading():
 
         docs = gather_documents(path)
         assert docs == [('doc1', text)]
+
+
+def test_utf8_multi_file_assembly():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir)
+        part1 = path / 'doc1_part1.txt'
+        part2 = path / 'doc1_part2.txt'
+        part1.write_text('hello')
+        part2.write_text('world')
+
+        docs = gather_documents(path)
+        assert docs == [('doc1', 'hello\nworld')]


### PR DESCRIPTION
## Summary
- extend `tests/test_aggregator.py` with a test that creates two UTF‑8
  files and verifies `gather_documents` combines them

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ff22f26f8832b922fd1c1e9aef142