### PR TITLE
Add snippet context to classification explanations

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,8 @@ python -m src.main --input data --output output/results.csv
 
 This runs the rule-based classifier on all text files under `data/` and writes the classification results to `output/results.csv`.
 
+The CSV file contains a `comment` column that lists each matched pattern along
+with a short snippet of the surrounding text (about 450 characters around the
+match). This provides context for why a category was assigned.
+
 See `docs/architecture.md` for an overview of the modules and `docs/roadmap.md` for ideas on next steps.

--- a/src/classifier.py
+++ b/src/classifier.py
@@ -24,7 +24,10 @@ class RuleBasedClassifier:
             for pattern in patterns:
                 m = re.search(pattern, text)
                 if m:
+                    snippet_start = max(m.start() - 225, 0)
+                    snippet_end = min(m.end() + 225, len(text))
+                    snippet = text[snippet_start:snippet_end]
                     if category not in results:
                         results[category] = Explanation(category)
-                    results[category].add_match(pattern, m.group(0))
+                    results[category].add_match(pattern, m.group(0), snippet)
         return results

--- a/src/explanation.py
+++ b/src/explanation.py
@@ -10,13 +10,15 @@ class Explanation:
     category: str
     matches: List[str] = field(default_factory=list)
     patterns: List[str] = field(default_factory=list)
+    snippets: List[str] = field(default_factory=list)
 
-    def add_match(self, pattern: str, text: str) -> None:
-        """Record a ``pattern`` that matched the provided text fragment."""
+    def add_match(self, pattern: str, text: str, snippet: str) -> None:
+        """Record a ``pattern`` that matched ``text`` with surrounding ``snippet``."""
         self.matches.append(text)
         self.patterns.append(pattern)
+        self.snippets.append(snippet)
 
     def as_text(self) -> str:
-        """Return a semicolon-separated summary of matches."""
-        pairs = [f"{p} -> {m}" for p, m in zip(self.patterns, self.matches)]
+        """Return a semicolon-separated summary of matches using snippets."""
+        pairs = [f"{p} -> {s}" for p, s in zip(self.patterns, self.snippets)]
         return '; '.join(pairs)

--- a/src/reporting.py
+++ b/src/reporting.py
@@ -21,6 +21,6 @@ def write_csv(results: Dict[str, Dict[str, Explanation]], output_path: Path) -> 
                     row.append('1')
                 else:
                     row.append('')
-            explanations = [categories[cat].as_text() for cat in categories]
+            explanations = [categories[cat].as_text() for cat in CATEGORY_PRIORITY if cat in categories]
             row.append(' | '.join(explanations))
             writer.writerow(row)

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,0 +1,12 @@
+import pathlib
+
+from src.classifier import RuleBasedClassifier
+
+
+def test_snippet_length():
+    text = "a" * 300 + "інститут" + "b" * 300
+    clf = RuleBasedClassifier(pathlib.Path('criteria.yml'))
+    results = clf.classify(text)
+    exp = results['Інститут']
+    snippet = exp.snippets[0]
+    assert 450 <= len(snippet) <= 460


### PR DESCRIPTION
## Summary
- record short context snippets for every regex match
- include snippets in classifier explanations and CSV output
- document the new comment column behaviour
- test snippet extraction length

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ff58a38ac832b94821ad7a2306ce0